### PR TITLE
Install required hybrid ABI utilities in jails

### DIFF
--- a/src/share/poudriere/include/hybridset.sh
+++ b/src/share/poudriere/include/hybridset.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# Copyright (c) 2023 Konrad Witaszczyk
+#
+# This software was developed by the University of Cambridge Department of
+# Computer Science and Technology with support from Innovate UK project 105694,
+# "Digital Security by Design (DSbD) Technology Platform Prototype".
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+_datadir_exists() {
+	if [ ! -d "${MASTER_DATADIR}" ]; then
+		err 1 "${1}: '${MASTER_DATADIR_ABS}' does not exist"
+	fi
+}
+
+hybridset_init() {
+	mkdir -p "${MASTER_DATADIR}/hybridset"
+}
+
+hybridset_exists() {
+	_datadir_exists hybridset_exists
+	[ -d "${MASTER_DATADIR_ABS}/hybridset" ]
+}
+
+hybridset_contains() {
+	_datadir_exists hybridset_contains
+	[ $# -eq 2 ] || eargs hybridset_contains pkgname dep_pkgname
+	local pkgname="$1"
+	local dep_pkgname="$2"
+	local pkg_dir_name
+
+	[ -d "${MASTER_DATADIR_ABS}/hybridset/${pkgname}/${dep_pkgname}" ]
+}
+
+hybridset_add() {
+	_datadir_exists hybridset_add
+	[ $# -eq 2 ] || eargs hybridset_add pkgname dep_pkgname
+	local pkgname="$1"
+	local dep_pkgname="$2"
+
+	mkdir -p "${MASTER_DATADIR_ABS}/hybridset/${pkgname}/${dep_pkgname}"
+}
+
+hybridset_list() {
+	_datadir_exists hybridset_list
+	[ $# -eq 0 ] || eargs hybridset_list
+
+	(cd "${MASTER_DATADIR_ABS}" && find "hybridset" -type d -depth 2 | cut -d / -f 3)
+}


### PR DESCRIPTION
Find hybrid ABI utilities required by ports, don't treat them as dependencies for ports scheduled for building that required them and install the utilities in a Poudriere jail template.

Note that a port that is both scheduled for building and required as a hybrid ABI utility by another port will be scheduled for building but its failed build will not affect its reverse dependencies.

The utilities are installed in the Poudriere jail template in advance because Poudriere jails don't have Internet access.