### PR TITLE
Improve toolchain and hybrid ABI pkg bootstrapping

### DIFF
--- a/src/share/poudriere/include/hybridset.sh
+++ b/src/share/poudriere/include/hybridset.sh
@@ -68,3 +68,31 @@ hybridset_list() {
 
 	(cd "${MASTER_DATADIR_ABS}" && find "hybridset" -type d -depth 2 | cut -d / -f 3 | sort -u)
 }
+
+hybridset_pkgcmd() {
+	[ $# -ge 2 ] || eargs hybridset_pkgcmd rootdir pkgrootdir
+	local rootdir="$1"
+	local pkgrootdir="$2"
+	shift 2
+	local host_abi
+	local pkgcmd
+
+	get_host_abi host_abi
+	if [ "${host_abi}" = "purecap" ]; then
+		pkgcmd="pkg64"
+		abifile="/usr/sbin/pkg64"
+	else
+		pkgcmd="pkg"
+		abifile="/usr/bin/uname"
+	fi
+
+	env ABI_FILE="${abifile}" \
+	    IGNORE_OSVERSION=yes \
+	    PKG_DBDIR="${rootdir}${pkgrootdir}/var/db/pkg64" \
+	    PKG_CACHEDIR="${rootdir}${pkgrootdir}/var/cache/pkg64" \
+	    ASSUME_ALWAYS_YES=yes \
+	    ${pkgcmd} \
+	    -R "${rootdir}/etc/pkg64" \
+	    -r "${rootdir}${pkgrootdir}" \
+	    "${@}"
+}

--- a/src/share/poudriere/include/hybridset.sh
+++ b/src/share/poudriere/include/hybridset.sh
@@ -66,5 +66,5 @@ hybridset_list() {
 	_datadir_exists hybridset_list
 	[ $# -eq 0 ] || eargs hybridset_list
 
-	(cd "${MASTER_DATADIR_ABS}" && find "hybridset" -type d -depth 2 | cut -d / -f 3)
+	(cd "${MASTER_DATADIR_ABS}" && find "hybridset" -type d -depth 2 | cut -d / -f 3 | sort -u)
 }

--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -867,21 +867,6 @@ install_from_tar() {
 	build_native_xtools
 }
 
-install_toolchain() {
-	if [ "${OS}" = "CheriBSD" ]; then
-		msg "Installing toolchain for ${OS} ${VERSION} ${ARCH}"
-		cp -a "${SCRIPTPREFIX}/toolchain" "${JAILMNT}/toolchain"
-		mkdir -p "${JAILMNT}/toolchain/usr/share/keys/pkg"
-		cp -a "${JAILMNT}/usr/share/keys/pkg/trusted" \
-		    "${JAILMNT}/toolchain/usr/share/keys/pkg/trusted"
-		pkg64 -r "${JAILMNT}/toolchain" install -qy llvm-base
-		if [ $? -ne 0 ]; then
-			err 1 "Failed to install llvm-base"
-		fi
-		sudo pkg64 -r "${JAILMNT}/toolchain" clean -aqy
-	fi
-}
-
 create_jail() {
 	local IFS
 
@@ -1027,10 +1012,6 @@ create_jail() {
 	jset ${JAILNAME} pkgbase ${BUILD_PKGBASE}
 
 	setup_rc_conf
-
-	if [ "${METHOD}" != "null" ]; then
-		install_toolchain
-	fi
 
 	if [ -r "${SRC_BASE:?}/sys/conf/newvers.sh" ]; then
 		RELEASE=$(update_version "${version_extra}")


### PR DESCRIPTION
This PR introduces two main changes:
1. Toolchain is bootstrapped when a jail is started instead of when it is created.
2. Hybrid ABI pkg is bootstrapped for both `poudriere bulk` and `poudriere jail -s` commands.

The above changes allow to use a CheriBSD root filesystem directory without polluting it with a Poudriere-specific toolchain and allow to debug build issues using hybrid ABI utilities in `poudriere jail -s`. It also prepares us to use other toolchain packages built for a Poudriere host (either CheriBSD on Morello hardware or FreeBSD with the user mode), e.g. to build CHERI-RISC-V packages custom ABI packages.